### PR TITLE
Deprecate MASWE-0034

### DIFF
--- a/weaknesses/MASVS-AUTH/MASWE-0034.md
+++ b/weaknesses/MASVS-AUTH/MASWE-0034.md
@@ -5,14 +5,10 @@ alias: insecure-confirm-credentials
 platform: [android]
 profiles: [L2]
 mappings:
-  masvs-v2: [MASVS-AUTH-1]
+  masvs-v2: [MASVS-AUTH-2]
   cwe: [287, 319]
 
-draft:
-  description: https://mas.owasp.org/MASTG/tests/android/MASVS-AUTH/MASTG-TEST-0017/
-  topics:
-  - Confirm Credentials
-status: placeholder
-
+status: deprecated
+covered_by: [MASWE-0044]
+deprecation_note: Content overlap. Confirm Credentials is a form of local authentication that will have a dedicated MASTG test.
 ---
-

--- a/weaknesses/MASVS-CRYPTO/MASWE-0013.md
+++ b/weaknesses/MASVS-CRYPTO/MASWE-0013.md
@@ -8,9 +8,6 @@ mappings:
   masvs-v1: [MSTG-CRYPTO-1]
   masvs-v2: [MASVS-CRYPTO-2]
 status: deprecated
+covered_by: [MASWE-0014]
+deprecation_note: Content overlap.
 ---
-
-
-!!! warning "Deprecated"
-
-    This weakness was deprecated in favor of @MASWE-0014 because of an overlap in the content.


### PR DESCRIPTION
Due to content overlap. Confirm Credentials is a form of local authentication that will have a dedicated MASTG test.

