### PR TITLE
Add MASWE-0118 placeholder: Clearing the WebView resources documentation

### DIFF
--- a/weaknesses/MASVS-PLATFORM/MASWE-0118.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0118.md
@@ -1,5 +1,5 @@
 ---
-title: Data Minimisation Measures in Caches Not Implemented
+title: Sensitive Data Not Removed After Use
 id: MASWE-0118
 alias: data-minimisation
 platform: [android, ios]


### PR DESCRIPTION
## Description

Add MASWE-0118 placeholder: Clearing the WebView resources documentation

Required by https://github.com/OWASP/mastg/issues/2975