### PR TITLE
  Define emulator detection weakness (MASWE-0099)

### DIFF
--- a/weaknesses/MASVS-RESILIENCE/MASWE-0099.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0099.md
@@ -10,6 +10,7 @@ mappings:
   cwe: [693]
 observed_examples:
 - https://doi.org/10.1007/978-3-030-00470-5_1
+- https://ieeexplore.ieee.org/document/10935812
 status: new
 ---
 
@@ -17,21 +18,20 @@ status: new
 
 Emulator detection aims to identify when an app runs inside an emulated environment. If an app does not implement these checks, attackers can run the app in controlled environments at scale and observe or automate behavior that would be harder to perform on physical devices.
 
+Also, in the case of Android, as the AOSP operating system and kernel source code are available, the Android emulators can be arbitrairly modified to include platform instrumentation that is harder to detect than common application instrumentation.
+
 ## Impact
 
-- **Bypass Protection Mechanism**: Missing emulator detection allows execution in environments that simplify tampering and analysis.
-- **Scalable Abuse and Automation**: Emulators support large-scale automation, which can enable fraud or abuse that depends on high volume.
-- **Increased Reverse Engineering Exposure**: Emulators reduce the cost of dynamic analysis and instrumentation, exposing sensitive logic or data.
+- **Bypass Protection Mechanisms**: Missing emulator detection allows execution in environments that simplify tampering and analysis and also allow for a deeper level of instrumentation in the case of Android.
 
 ## Modes of Introduction
 
-- **Missing Requirement**: Emulator detection is not included in the security requirements or threat model.
-- **Disabled in Production**: Checks exist only in debug builds or are disabled through configuration.
-- **Limited Coverage**: Checks run only at startup and are not enforced before sensitive actions.
+- **Missing Requirement**: Emulator detection is not included in the security requirements or threat model for the application.
+- **Disabled in Production**: Checks exist only in debug builds or are disabled through configuration, not being available in the release build.
+- **Limited Coverage**: Checks run only at a certain time during the application logic (e.g, startup) and are not enforced throughout the app lifecycle (e.g., before sensitive actions).
 
 ## Mitigations
 
-- Define emulator detection as a runtime risk signal for sensitive flows and document how it influences access decisions.
+- Define emulator detection as a runtime risk signal for sensitive flows.
 - Use multiple independent indicators and evaluate them together rather than relying on a single check.
-- Revalidate at critical actions or high-risk workflows to limit one-time bypasses.
 - Combine client-side checks with server-side evaluation or integrity signals when feasible.


### PR DESCRIPTION
This PR closes #39 

## Description

- Replaced placeholder with full MASWE entry for missing emulator detection.
- Added overview, impact, modes of introduction, and mitigations aligned with MASVS/MASTG guidance.
- Included MASVS v2 mapping and CWE 693 reference.

  ## Notes

- Observed examples can be expanded if preferred; current entry uses a published research reference.

-------------------

[x] I have read the contributing guidelines.
