### PR TITLE
Fix ref in MASWE-0050

### DIFF
--- a/weaknesses/MASVS-CODE/MASWE-0050.md
+++ b/weaknesses/MASVS-CODE/MASWE-0050.md
@@ -23,7 +23,6 @@ mappings:
 refs:
 - https://developer.android.com/topic/security/risks/path-traversal
 - https://developer.android.com/topic/security/risks/sql-injection
-- unsafe-deserialization
 - https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html
 ---
 


### PR DESCRIPTION
Removed reference to 'unsafe-deserialization' from the list of risks.
