### PR TITLE
Fix URL checker: allow creativecommons.org and update README badge

### DIFF
--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -8,7 +8,7 @@
         },
         {
             "comment": "Sites that are live but block automated clients (bot challenge, consent-redirect loop or rate limiting)",
-            "pattern": "^https://(www\\.)?(statista\\.com|researchgate\\.net|ieeexplore\\.ieee\\.org)"
+            "pattern": "^https?://(www\\.)?(statista\\.com|researchgate\\.net|ieeexplore\\.ieee\\.org|creativecommons\\.org)"
         },
         {
             "pattern": "^https://support\\.google\\.com/"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OWASP Mobile Application Security Weakness Enumeration (MASWE)
 
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/)
-[![Creative Commons License](https://img.shields.io/github/license/OWASP/maswe)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
+[![Creative Commons License](https://img.shields.io/github/license/OWASP/maswe?color=48A646)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
 
 [![Markdown Linter](https://github.com/OWASP/maswe/workflows/Markdown%20Linter/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/markdown-linter.yml)
 [![URL Checker](https://github.com/OWASP/maswe/workflows/URL%20Checker/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/url-checker.yml)


### PR DESCRIPTION
## Summary

- URL Checker CI fails on `main` because `creativecommons.org` returns 403 to automated clients (the CC BY-SA boilerplate links in `License.md`). Added `creativecommons.org` to the existing "live but blocks automated clients" ignore pattern and broadened it to match `http://` as well as `https://`.
- Minor: README license badge color changed for better visibility.

## Test plan

- `url-checker` workflow should pass on this branch.

*AI tool usage disclosure: prepared with Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)