### PR TITLE
Add MASWE Build workflow to generate OWASP_MASWE.yaml

### DIFF
--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -1,0 +1,51 @@
+name: MASWE Build
+
+on: [push, workflow_dispatch]
+
+jobs:
+  Generate-MASWE-Documents:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Set MASWE_VERSION to env
+      run: echo "MASWE_VERSION=$(curl -s https://api.github.com/repos/OWASP/maswe/tags | jq '.[0].name' | sed 's/\"//g')" >> $GITHUB_ENV
+
+    - name: Set DEV MASWE_VERSION if it's not a tag
+      if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      run: echo "MASWE_VERSION=${{env.MASWE_VERSION}}-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+    - name: Install dependencies
+      run: pip install pyyaml
+
+    - name: Generate MASWE yaml
+      run: python3 ./tools/generate_maswe_yaml.py -v ${{ env.MASWE_VERSION }}
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: OWASP_MASWE
+        path: OWASP_MASWE*
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [Generate-MASWE-Documents]
+    if: startsWith(github.ref, 'refs/tags/') && (github.actor == 'cpholguera' || github.actor == 'sushi2k')
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Move all files to the root folder
+        run: mv OWASP_MASWE*/* .
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          prerelease: false
+          draft: true
+          generate_release_notes: true
+          discussion_category_name: Announcements
+          files: |
+            OWASP_MASWE.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ drafts/
 Payload/
 .vscode/settings.json
 .cache/
+OWASP_MASWE.yaml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/)
 [![Creative Commons License](https://img.shields.io/github/license/OWASP/maswe)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
 
+[![MASWE Build](https://github.com/OWASP/maswe/workflows/MASWE%20Build/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/docgenerator.yml)
 [![Markdown Linter](https://github.com/OWASP/maswe/workflows/Markdown%20Linter/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/markdown-linter.yml)
 [![URL Checker](https://github.com/OWASP/maswe/workflows/URL%20Checker/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/url-checker.yml)
 

--- a/tools/generate_maswe_yaml.py
+++ b/tools/generate_maswe_yaml.py
@@ -1,0 +1,46 @@
+"""Generate the OWASP MASWE YAML from the weakness front matter."""
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parent.parent
+
+METADATA = {
+    "title": "Mobile Application Security Weakness Enumeration (MASWE)",
+    "remarks": "The OWASP MASWE (Mobile Application Security Weakness Enumeration) is a list of common security and privacy weaknesses in mobile applications. It acts as the bridge between the OWASP MASVS and the OWASP MASTG.",
+}
+
+
+def front_matter(path: Path) -> dict:
+    _, contents = path.read_text().split("---", 1)
+    contents, _ = contents.split("---", 1)
+    return yaml.safe_load(contents)
+
+
+def get_maswe_dict(maswe_version: str, weaknesses_dir: Path) -> dict:
+    weaknesses = {}
+    for path in sorted(weaknesses_dir.glob("**/MASWE-*.md"), key=lambda path: path.stem):
+        entry = front_matter(path)
+        weaknesses[entry["id"]] = entry
+
+    return {"metadata": METADATA | {"version": maswe_version}, "weaknesses": weaknesses}
+
+
+def main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("-w", "--weaknesses", help="Weaknesses Directory", type=Path, default=ROOT / "weaknesses")
+    parser.add_argument("-v", "--version", help="MASWE version", default="vx.x.x")
+    parser.add_argument("-o", "--output", help="Output file", type=Path, default=Path("OWASP_MASWE.yaml"))
+    arguments = parser.parse_args()
+
+    maswe = get_maswe_dict(arguments.version, arguments.weaknesses)
+
+    with arguments.output.open("w") as f:
+        yaml.dump(maswe, f, default_flow_style=False, sort_keys=False, allow_unicode=True, width=float("inf"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a release/build workflow to the MASWE repo, mirroring [`docgenerator.yml`](https://github.com/OWASP/masvs/blob/master/.github/workflows/docgenerator.yml) in the MASVS repo.

- **`.github/workflows/docgenerator.yml`** (*MASWE Build*): on every push and on `workflow_dispatch`, it resolves the MASWE version (latest tag, suffixed with the short SHA when not building a tag), generates `OWASP_MASWE.yaml`, and uploads it as an artifact. On a tag push by a maintainer, a second job attaches the YAML to a **draft** GitHub release with generated release notes and an `Announcements` discussion.
- **`tools/generate_maswe_yaml.py`**: the `export_maswe_yaml.py` script, moved into `tools/` and renamed to match the MASVS naming. It collects the YAML front matter of every `weaknesses/**/MASWE-*.md` file, keyed by MASWE ID.
- `OWASP_MASWE.yaml` added to `.gitignore` (build artifact), plus a build badge in the README.
