### PR TITLE
Fix URL checker failures on main (dead links + ignore patterns)

### DIFF
--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -8,7 +8,7 @@
         },
         {
             "comment": "Sites that are live but block automated clients (bot challenge, consent-redirect loop or rate limiting)",
-            "pattern": "^https://(www\\.)?(statista\\.com|researchgate\\.net|ieeexplore\\.ieee\\.org)"
+            "pattern": "^https?://(www\\.)?(statista\\.com|researchgate\\.net|ieeexplore\\.ieee\\.org|creativecommons\\.org)"
         },
         {
             "pattern": "^https://support\\.google\\.com/"

--- a/.github/workflows/config/url-checker-config.json
+++ b/.github/workflows/config/url-checker-config.json
@@ -12,6 +12,10 @@
         },
         {
             "pattern": "^https://support\\.google\\.com/"
+        },
+        {
+            "comment": "Wayback Machine snapshots frequently return 503 to automated clients",
+            "pattern": "^https://web\\.archive\\.org/"
         }
     ],
     "httpHeaders": [

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # OWASP Mobile Application Security Weakness Enumeration (MASWE)
 
 [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship%20project-48A646.svg)](https://owasp.org/projects/)
-[![Creative Commons License](https://img.shields.io/github/license/OWASP/maswe)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
+[![Creative Commons License](https://img.shields.io/github/license/OWASP/maswe?color=48A646)](https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0")
 
 [![MASWE Build](https://github.com/OWASP/maswe/workflows/MASWE%20Build/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/docgenerator.yml)
 [![Markdown Linter](https://github.com/OWASP/maswe/workflows/Markdown%20Linter/badge.svg)](https://github.com/OWASP/maswe/actions/workflows/markdown-linter.yml)

--- a/weaknesses/MASVS-CRYPTO/MASWE-0017.md
+++ b/weaknesses/MASVS-CRYPTO/MASWE-0017.md
@@ -26,7 +26,7 @@ Many of the platform's data-protection mechanisms assume a device credential exi
 
 ## Modes of Introduction
 
-- **No Secure-Lock Check**: Enabling sensitive features without verifying the device lock state, e.g., [`KeyguardManager.isDeviceSecure()`](https://developer.android.com/reference/android/app/KeyguardManager#isDeviceSecure()) on Android or [`LAContext.canEvaluatePolicy(_:error:)`](https://developer.apple.com/documentation/localauthentication/lacontext/canevaluatepolicy%28_%3Aerror%3A%29) on iOS.
+- **No Secure-Lock Check**: Enabling sensitive features without verifying the device lock state, e.g., [`KeyguardManager.isDeviceSecure()`](https://developer.android.com/reference/android/app/KeyguardManager#isDeviceSecure()) on Android or [`LAContext.canEvaluatePolicy(_:error:)`](https://developer.apple.com/documentation/localauthentication/lacontext/canevaluatepolicy(_:error:)) on iOS.
 - **Data Protection Not Tied to the Passcode**: Storing sensitive items on iOS without passcode-dependent protection classes (e.g. [`kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly`](https://developer.apple.com/documentation/security/ksecattraccessiblewhenpasscodesetthisdeviceonly)), so the data remains available even when no passcode is set.
 - **Stale Device-Lock Assumption**: Checking the device-lock configuration only during onboarding or feature enrollment and continuing to enable the functionality after the device credential has been removed or the required authentication policy is no longer available.
 

--- a/weaknesses/MASVS-PRIVACY/MASWE-0068.md
+++ b/weaknesses/MASVS-PRIVACY/MASWE-0068.md
@@ -23,7 +23,7 @@ refs:
 - https://developer.apple.com/app-store/user-privacy-and-data-use/
 - https://developer.apple.com/documentation/apptrackingtransparency/
 - https://developer.apple.com/documentation/adsupport/asidentifiermanager/advertisingidentifier
-- https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor/
+- https://developer.apple.com/documentation/uikit/uidevice/identifierforvendor
 - https://developer.apple.com/app-store/ad-attribution/
 - https://developer.apple.com/documentation/adattributionkit
 - https://gdpr-info.eu/recitals/no-30/


### PR DESCRIPTION
## Summary

The `URL Checker` workflow has failed on every push to `main` since April (latest: https://github.com/OWASP/maswe/actions/runs/32018032073). This PR supersedes #191 and fixes all causes seen across the recent runs:

- **MASWE-0068**: `developer.apple.com/.../uidevice/1620059-identifierforvendor/` → 404. Updated to the current URL `.../uidevice/identifierforvendor`.
- **MASWE-0017**: `lacontext/canevaluatepolicy%28_%3Aerror%3A%29` → 404. Apple rejects the percent-encoded form; switched to the unencoded `canevaluatepolicy(_:error:)` as used in MASTG.
- **url-checker-config.json**: added `web.archive.org` to the ignore patterns (Wayback snapshots intermittently return 503; MASTG already ignores this host). Also carries over the change from #191: `creativecommons.org` added to the "blocks automated clients" pattern and the pattern broadened to `http://` (the `License.md` links returned 403 in run 30889932085).
- **README**: license badge color change from #191.

## Test plan

- [x] `markdown-link-check` run locally with the repo config on the touched files: all links return 200 / ignored.
- [x] `markdownlint-cli2` clean on the touched files.
- [x] `URL Checker (PR)` workflow green on this PR.

*AI tool usage disclosure: prepared with Claude Code.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)